### PR TITLE
perf: check for headers before generating rows

### DIFF
--- a/demo/api.min.js
+++ b/demo/api.min.js
@@ -90,18 +90,20 @@ class AuroTable extends LitElement {
   extractRows() {
     const tableBody = this.shadowRoot.querySelector('tbody');
 
-    this.componentData.forEach((row) => {
-      const tr = document.createElement('tr');
+    if (this.componentData && this.columnHeaders) {
+      this.componentData.forEach((row) => {
+        const tr = document.createElement('tr');
 
-      this.columnHeaders.forEach((column) => {
-        const td = document.createElement('td');
-        const content = row[column] || '';
-        td.innerHTML = content;
-        tr.appendChild(td);
+        this.columnHeaders.forEach((column) => {
+          const td = document.createElement('td');
+          const content = row[column] || '';
+          td.innerHTML = content;
+          tr.appendChild(td);
+        });
+
+        tableBody.appendChild(tr);
       });
-
-      tableBody.appendChild(tr);
-    });
+    }
   }
 
   // function that renders the HTML and CSS into  the scope of the component

--- a/demo/index.min.js
+++ b/demo/index.min.js
@@ -90,18 +90,20 @@ class AuroTable extends LitElement {
   extractRows() {
     const tableBody = this.shadowRoot.querySelector('tbody');
 
-    this.componentData.forEach((row) => {
-      const tr = document.createElement('tr');
+    if (this.componentData && this.columnHeaders) {
+      this.componentData.forEach((row) => {
+        const tr = document.createElement('tr');
 
-      this.columnHeaders.forEach((column) => {
-        const td = document.createElement('td');
-        const content = row[column] || '';
-        td.innerHTML = content;
-        tr.appendChild(td);
+        this.columnHeaders.forEach((column) => {
+          const td = document.createElement('td');
+          const content = row[column] || '';
+          td.innerHTML = content;
+          tr.appendChild(td);
+        });
+
+        tableBody.appendChild(tr);
       });
-
-      tableBody.appendChild(tr);
-    });
+    }
   }
 
   // function that renders the HTML and CSS into  the scope of the component

--- a/src/auro-table.js
+++ b/src/auro-table.js
@@ -91,18 +91,20 @@ export class AuroTable extends LitElement {
   extractRows() {
     const tableBody = this.shadowRoot.querySelector('tbody');
 
-    this.componentData.forEach((row) => {
-      const tr = document.createElement('tr');
+    if (this.componentData && this.columnHeaders) {
+      this.componentData.forEach((row) => {
+        const tr = document.createElement('tr');
 
-      this.columnHeaders.forEach((column) => {
-        const td = document.createElement('td');
-        const content = row[column] || '';
-        td.innerHTML = content;
-        tr.appendChild(td);
+        this.columnHeaders.forEach((column) => {
+          const td = document.createElement('td');
+          const content = row[column] || '';
+          td.innerHTML = content;
+          tr.appendChild(td);
+        });
+
+        tableBody.appendChild(tr);
       });
-
-      tableBody.appendChild(tr);
-    });
+    }
   }
 
   // function that renders the HTML and CSS into  the scope of the component


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Add a check to ensure 'componentData' and 'columnHeaders' are present before generating table rows.